### PR TITLE
[GRDM-44340] Fix issue with binder_repo_url extraction in syncToRDM function

### DIFF
--- a/R/syncToRDM.R
+++ b/R/syncToRDM.R
@@ -6,10 +6,10 @@ syncToRDM <- function() {
   jh_env = fromJSON('~/.config/grdm/env.json')
   jh_user = jh_env['JUPYTERHUB_USER']
   jh_server_name = jh_env['JUPYTERHUB_SERVER_NAME']
-  binder_repo_url = jh_env['BINDER_REPO_URL']
+  binder_repo_url <- jh_env[['BINDER_REPO_URL']]
   yyyymmdd = format(Sys.time(), '%Y%m%d')
-  storage_provider = strsplit(binder_repo_url, "/")[[1]][5]
-  to_path = sprintf('/mnt/rdm/%s/result-%s-%s-%s/', stoarge_provider, jh_user, yyyymmdd, jh_server_name)
+  storage_provider <- strsplit(binder_repo_url, "/")[[1]][5]
+  to_path <- sprintf('/mnt/rdm/%s/result-%s-%s-%s/', storage_provider, jh_user, yyyymmdd, jh_server_name)
   cat(sprintf('Syncing...: ~/result -> %s\n', to_path))
   if (!dir.exists(to_path)) {
     dir.create(to_path)


### PR DESCRIPTION
### 修正内容
RStudioからの「Sync to RDM」を実行した際に発生する以下のエラーを修正しました：
`Error in strsplit(binder_repo_url, "/") : non-character argument`

### 背景
このエラーは、`jh_env['BINDER_REPO_URL']` がリスト型として扱われているために発生していました。
これを文字列型として正しく扱うように修正しました。
